### PR TITLE
Include generationrequest info for enhancement created event

### DIFF
--- a/src/main/avro/org/jboss/sbomer/events/common/GenerationRequestSpec.avsc
+++ b/src/main/avro/org/jboss/sbomer/events/common/GenerationRequestSpec.avsc
@@ -29,6 +29,18 @@
           }
         ]
       }
+    },
+    {
+      "name": "handlerProvidedOptions",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": "string"
+        }
+      ],
+      "default": null,
+      "doc": "Optional map of key-value configuration options provided by the handler. Allows for passing specific flags or configurations unique to the generation being requested by the handler."
     }
   ]
 }

--- a/src/main/avro/org/jboss/sbomer/events/orchestration/EnhancementCreated.avsc
+++ b/src/main/avro/org/jboss/sbomer/events/orchestration/EnhancementCreated.avsc
@@ -40,6 +40,15 @@
             "name": "enhancer",
             "type": "org.jboss.sbomer.events.common.EnhancerSpec",
             "doc": "The specific enhancer from the recipe that should be executed in this step."
+          },
+          {
+            "name": "generationRequest",
+            "type": [
+              "null", 
+              "org.jboss.sbomer.events.common.GenerationRequestSpec"
+            ],
+            "default": null,
+            "doc": "Optional: The full generation request context, including the target identifier (image URL)."
           }
         ]
       }


### PR DESCRIPTION
Adding an optional field the the enhancement.created event in case the enhancer relies on the target and identifier information to do its thing